### PR TITLE
feat: 회원 탈퇴 백엔드, 쿠키 관련 테스트 코드 수정

### DIFF
--- a/backend/src/main/java/com/ll/TeamProject/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/controller/UserController.java
@@ -2,14 +2,14 @@ package com.ll.TeamProject.domain.user.controller;
 
 import com.ll.TeamProject.domain.user.dto.UserDto;
 import com.ll.TeamProject.domain.user.entity.SiteUser;
+import com.ll.TeamProject.domain.user.service.UserService;
 import com.ll.TeamProject.global.rq.Rq;
+import com.ll.TeamProject.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "bearerAuth")
 public class UserController {
     private final Rq rq;
+    private final UserService userService;
 
     @GetMapping("/me")
     @Operation(summary = "내 정보")
@@ -25,6 +26,16 @@ public class UserController {
         SiteUser actor = rq.findByActor().get();
 
         return new UserDto(actor);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "회원 탈퇴 (soft)")
+    public RsData<UserDto> deleteUser(@PathVariable("id") long id) {
+        SiteUser userToDelete = userService.delete(id);
+
+        return new RsData<>(
+                "200-1", "회원정보가 삭제되었습니다.", new UserDto(userToDelete)
+        );
     }
 
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/entity/SiteUser.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/entity/SiteUser.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -82,5 +83,11 @@ public class SiteUser extends BaseTime {
 
     private boolean isAdmin() {
         return this.role == Role.ADMIN;
+    }
+
+    public void delete() {
+        this.nickname = "탈퇴한 사용자";
+        this.username = String.valueOf(UUID.randomUUID());
+        this.email = username + "@deleted";
     }
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/entity/SiteUser.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/entity/SiteUser.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -45,8 +46,9 @@ public class SiteUser extends BaseTime {
     @Column(unique = true)
     private String apiKey;
 
-    @Column
     private boolean isDeleted;
+
+    private LocalDateTime deletedDate;
 
     public SiteUser(long id, String username, String nickname, Role role) {
         super();
@@ -99,5 +101,6 @@ public class SiteUser extends BaseTime {
 
     public void delete(boolean changed) {
         this.isDeleted = changed;
+        this.deletedDate = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/entity/SiteUser.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/entity/SiteUser.java
@@ -45,6 +45,9 @@ public class SiteUser extends BaseTime {
     @Column(unique = true)
     private String apiKey;
 
+    @Column
+    private boolean isDeleted;
+
     public SiteUser(long id, String username, String nickname, Role role) {
         super();
         this.setId(id);
@@ -85,9 +88,16 @@ public class SiteUser extends BaseTime {
         return this.role == Role.ADMIN;
     }
 
-    public void delete() {
-        this.nickname = "탈퇴한 사용자";
-        this.username = String.valueOf(UUID.randomUUID());
-        this.email = username + "@deleted";
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+
+    public void deleteUsernameEmail() {
+        this.username = "deleted_" + UUID.randomUUID();
+        this.email = username + "@deleted.com";
+    }
+
+    public void delete(boolean changed) {
+        this.isDeleted = changed;
     }
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/repository/UserRepository.java
@@ -15,7 +15,7 @@ public interface UserRepository extends JpaRepository<SiteUser, Long> {
 
     Page<SiteUser> findByRoleNot(Role role, PageRequest pageRequest);
 
-    Page<SiteUser> findByRoleAndEmailLike(Role role, String emailLike, PageRequest pageRequest);
+    Page<SiteUser> findByRoleAndEmailLikeAndIsDeletedFalse(Role role, String emailLike, PageRequest pageRequest);
 
-    Page<SiteUser> findByRoleAndUsernameLike(Role role, String usernameLike, PageRequest pageRequest);
+    Page<SiteUser> findByRoleAndUsernameLikeAndIsDeletedFalse(Role role, String usernameLike, PageRequest pageRequest);
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/service/UserService.java
@@ -57,8 +57,8 @@ public class UserService {
         searchKeyword = "%" + searchKeyword + "%"; // 일부만 입력해도 조회되도록
 
         return switch (searchKeywordType) {
-            case "email" -> userRepository.findByRoleAndEmailLike(Role.USER, searchKeyword, pageRequest);
-            default -> userRepository.findByRoleAndUsernameLike(Role.USER, searchKeyword, pageRequest);
+            case "email" -> userRepository.findByRoleAndEmailLikeAndIsDeletedFalse(Role.USER, searchKeyword, pageRequest);
+            default -> userRepository.findByRoleAndUsernameLikeAndIsDeletedFalse(Role.USER, searchKeyword, pageRequest);
         };
     }
 

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/service/UserService.java
@@ -159,7 +159,9 @@ public class UserService {
         }
 
         // 삭제 로직
-        userToDelete.delete();
+        userToDelete.changeNickname("탈퇴한 사용자");
+        userToDelete.deleteUsernameEmail();
+        userToDelete.delete(true);
         userRepository.save(userToDelete);
 
         return userToDelete;

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/service/UserService.java
@@ -6,6 +6,8 @@ import com.ll.TeamProject.domain.user.enums.AuthType;
 import com.ll.TeamProject.domain.user.enums.Role;
 import com.ll.TeamProject.domain.user.repository.AuthenticationRepository;
 import com.ll.TeamProject.domain.user.repository.UserRepository;
+import com.ll.TeamProject.global.exceptions.ServiceException;
+import com.ll.TeamProject.global.rq.Rq;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -24,6 +26,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final AuthTokenService authTokenService;
     private final AuthenticationRepository authenticationRepository;
+    private final Rq rq;
 
     // username으로 찾기
     public Optional<SiteUser> findByUsername(String username) {
@@ -137,5 +140,28 @@ public class UserService {
         authenticationRepository.save(authentication);
 
         return user;
+    }
+
+    public SiteUser delete(long id) {
+        // 회원 존재 확인
+        Optional<SiteUser> userOptional = findById(id);
+        if(userOptional.isEmpty()) {
+            throw new ServiceException("401-1", "존재하지 않는 사용자입니다.");
+        }
+        SiteUser userToDelete = userOptional.get();
+
+        // 요청 사용자 확인
+        SiteUser actor = rq.getActor();
+
+        // 권한 확인
+        if(!userToDelete.getId().equals(actor.getId())) {
+            throw new ServiceException("403-1", "접근 권한이 없습니다.");
+        }
+
+        // 삭제 로직
+        userToDelete.delete();
+        userRepository.save(userToDelete);
+
+        return userToDelete;
     }
 }

--- a/backend/src/main/java/com/ll/TeamProject/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/ll/TeamProject/global/security/SecurityConfig.java
@@ -42,12 +42,16 @@ public class SecurityConfig {
                                 .permitAll()
 
                                 // 관리자 작업 권한 필요
-                                .requestMatchers("/admin")
+                                .requestMatchers("/admin/**")
                                 .hasAuthority("ROLE_ADMIN")
 
                                 // 로그인 요청 허용
                                 .requestMatchers("/login")
                                 .permitAll()
+
+                                // user 관련 인증 필요
+                                .requestMatchers("/user/**")
+                                .authenticated()
 
                                 // 정적자원 허용
                                 .requestMatchers("/static/**", "/images/**", "/css/**", "/js/**") // 정적 자원 예외 추가

--- a/backend/src/test/java/com/ll/TeamProject/domain/user/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/ll/TeamProject/domain/user/controller/AdminControllerTest.java
@@ -89,13 +89,11 @@ class AdminControllerTest {
                     assertThat(accessTokenCookie.getValue()).isNotBlank();
                     assertThat(accessTokenCookie.getPath()).isEqualTo("/");
                     assertThat(accessTokenCookie.isHttpOnly()).isTrue();
-                    assertThat(accessTokenCookie.getSecure()).isTrue();
 
                     Cookie apiKeyCookie = result.getResponse().getCookie("apiKey");
                     assertThat(apiKeyCookie.getValue()).isEqualTo(actor.getApiKey());
                     assertThat(apiKeyCookie.getPath()).isEqualTo("/");
                     assertThat(apiKeyCookie.isHttpOnly()).isTrue();
-                    assertThat(apiKeyCookie.getSecure()).isTrue();
                 }
         );
     }
@@ -336,14 +334,12 @@ class AdminControllerTest {
                     assertThat(accessTokenCookie.getMaxAge()).isEqualTo(0);
                     assertThat(accessTokenCookie.getPath()).isEqualTo("/");
                     assertThat(accessTokenCookie.isHttpOnly()).isTrue();
-//                    assertThat(accessTokenCookie.getSecure()).isTrue();
 
                     Cookie apiKeyCookie = result.getResponse().getCookie("apiKey");
                     assertThat(apiKeyCookie.getValue()).isEmpty();
                     assertThat(apiKeyCookie.getMaxAge()).isEqualTo(0);
                     assertThat(apiKeyCookie.getPath()).isEqualTo("/");
                     assertThat(apiKeyCookie.isHttpOnly()).isTrue();
-//                    assertThat(apiKeyCookie.getSecure()).isTrue();
                 });
     }
 

--- a/backend/src/test/java/com/ll/TeamProject/domain/user/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/ll/TeamProject/domain/user/controller/AdminControllerTest.java
@@ -346,4 +346,47 @@ class AdminControllerTest {
 //                    assertThat(apiKeyCookie.getSecure()).isTrue();
                 });
     }
+
+    @Test
+    @DisplayName("사용자 탈퇴")
+    void deleteUser() throws Exception {
+        SiteUser actor = userService.findByUsername("user1").get();
+        String actorAuthToken = userService.genAuthToken(actor);
+
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/user/2")
+                                .header("Authorization", "Bearer " + actorAuthToken)
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.msg").value("회원정보가 삭제되었습니다."))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.id").value(actor.getId()))
+                .andExpect(jsonPath("$.data.createDate").value(Matchers.startsWith(actor.getCreateDate().toString().substring(0, 25))))
+                .andExpect(jsonPath("$.data.modifyDate").value(Matchers.startsWith(actor.getModifyDate().toString().substring(0, 25))))
+                .andExpect(jsonPath("$.data.nickname").value("탈퇴한 사용자"));
+    }
+
+    @Test
+    @DisplayName("사용자 탈퇴 - 다른 사용자, 권한 없음")
+    void deleteUser2() throws Exception {
+        SiteUser actor = userService.findByUsername("user2").get();
+        String actorAuthToken = userService.genAuthToken(actor);
+
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/user/2")
+                                .header("Authorization", "Bearer " + actorAuthToken)
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.resultCode").value("403-1"))
+                .andExpect(jsonPath("$.msg").value("접근 권한이 없습니다."));
+    }
 }


### PR DESCRIPTION
회원 탈퇴 백엔드 부분입니다.

프론트는 내정보 같은 페이지 만들면서 함께 만들겠습니다!

---

회원이 탈퇴해도 공유된 캘린더 등은 남아있어야 할 것 같아서

soft delete 방식으로 만들었습니다.


사용자가 탈퇴를 요청할 시

isDeleted 필드가 true로 바뀌고

username, email, nickname 관련 개인정보가 지워지도록 구현했고

삭제된 정보는 복구할 수 없습니다.

탈퇴한 사용자는 다시 소셜 로그인하면 새로운 계정으로 생성됩니다.


deletedDate (삭제일) 를 SiteUser에 추가해서

이후 로깅이나 추가 관리를 위해 사용할 예정입니다.


또한 관리자 페이지에서 회원 명단을 조회할 때

삭제된 회원은 조회되지 않도록 수정했습니다.

---

추가로 이전에 수정했던 쿠키에 대해서

테스트 코드에 남아있는 부분이 있어서 수정했습니다.