### PR TITLE
Refactor/#67 schedule domain 

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -49,6 +49,10 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-mail:3.4.2")
 
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+	implementation ("org.mapstruct:mapstruct:1.6.3")
+
+	annotationProcessor ("org.mapstruct:mapstruct-processor:1.6.3")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/ll/TeamProject/domain/schedule/entity/Schedule.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/schedule/entity/Schedule.java
@@ -1,11 +1,10 @@
 package com.ll.TeamProject.domain.schedule.entity;
 
-
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.ll.TeamProject.domain.calendar.entity.Calendar;
 import com.ll.TeamProject.domain.user.entity.SiteUser;
 import com.ll.TeamProject.global.jpa.entity.BaseTime;
 import com.ll.TeamProject.global.jpa.entity.Location;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,29 +16,35 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class Schedule extends BaseTime {  // BaseTime : id (BaseEntity, no setter), 생성/수정일
-
+@NamedQueries({
+        @NamedQuery(
+                name = "Schedule.findOverlappingSchedules",
+                query = "SELECT s FROM Schedule s WHERE s.calendar.id = :calendarId AND (s.startTime < :endTime AND s.endTime > :startTime)"
+        ),
+        @NamedQuery(
+                name = "Schedule.findSchedulesByCalendarAndDateRange",
+                query = "SELECT s FROM Schedule s WHERE s.calendar.id = :calendarId AND (s.startTime < :endDate AND s.endTime > :startDate)"
+        )
+})
+public class Schedule extends BaseTime {
     @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "calendar_id", nullable = false)
-    private Calendar calendar; // 일정이 속한 캘린더
+    private Calendar calendar;
 
     @Column(length = 200)
-    private String title; // 일정 제목
+    private String title;
 
     @Column(columnDefinition = "TEXT")
-    private String description; // 일정 설명 (메모)
+    private String description;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private SiteUser user;
 
-    private LocalDateTime startTime; // 일정 시작 시간
-
-    private LocalDateTime endTime; // 일정 종료 시간
-
-    private Location location; // 일정 위치 정보
-
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Location location;
 
     public void update(String title, String description,
                        LocalDateTime startTime, LocalDateTime endTime, Location location) {

--- a/backend/src/main/java/com/ll/TeamProject/domain/schedule/mapper/ScheduleMapper.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/schedule/mapper/ScheduleMapper.java
@@ -1,0 +1,15 @@
+package com.ll.TeamProject.domain.schedule.mapper;
+
+import com.ll.TeamProject.domain.schedule.dto.ScheduleResponseDto;
+import com.ll.TeamProject.domain.schedule.entity.Schedule;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ScheduleMapper {
+
+    @Mapping(target = "calendarId", source = "calendar.id")
+    @Mapping(target = "description", expression = "java(schedule.getDescription() != null ? schedule.getDescription() : \"\")")
+    @Mapping(target = "modifyDate", expression = "java(schedule.getModifyDate() != null ? schedule.getModifyDate() : schedule.getCreateDate())")
+    ScheduleResponseDto toDto(Schedule schedule);
+}

--- a/backend/src/main/java/com/ll/TeamProject/domain/schedule/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/schedule/repository/ScheduleRepository.java
@@ -2,7 +2,6 @@ package com.ll.TeamProject.domain.schedule.repository;
 
 import com.ll.TeamProject.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
@@ -11,23 +10,15 @@ import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
-    // 특정 캘린더에서 겹치는 일정 조회
-    @Query("""
-    SELECT s FROM Schedule s WHERE s.calendar.id = :calendarId AND\s
-    (s.startTime < :endTime AND s.endTime > :startTime)
-   \s""")
+    // NamedQuery "Schedule.findOverlappingSchedules"를 사용
     List<Schedule> findOverlappingSchedules(@Param("calendarId") Long calendarId,
                                             @Param("startTime") LocalDateTime startTime,
                                             @Param("endTime") LocalDateTime endTime);
 
-
-    // 특정 캘린더 내 일정 조회
-    @Query("SELECT s FROM Schedule s WHERE s.calendar.id = :calendarId AND " +
-            "(s.startTime < :endDate AND s.endTime > :startDate)")
+    // NamedQuery "Schedule.findSchedulesByCalendarAndDateRange"를 사용
     List<Schedule> findSchedulesByCalendarAndDateRange(@Param("calendarId") Long calendarId,
                                                        @Param("startDate") LocalDateTime startDate,
                                                        @Param("endDate") LocalDateTime endDate);
-
 
     Optional<Schedule> findTopByOrderByIdDesc();
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/schedule/service/ScheduleService.java
@@ -5,6 +5,7 @@ import com.ll.TeamProject.domain.calendar.repository.CalendarRepository;
 import com.ll.TeamProject.domain.schedule.dto.ScheduleRequestDto;
 import com.ll.TeamProject.domain.schedule.dto.ScheduleResponseDto;
 import com.ll.TeamProject.domain.schedule.entity.Schedule;
+import com.ll.TeamProject.domain.schedule.mapper.ScheduleMapper;
 import com.ll.TeamProject.domain.schedule.repository.ScheduleRepository;
 import com.ll.TeamProject.domain.user.entity.SiteUser;
 import com.ll.TeamProject.global.exceptions.ServiceException;
@@ -27,12 +28,11 @@ public class ScheduleService {
     private final ScheduleRepository scheduleRepository;
     private final CalendarRepository calendarRepository;
     private final UserContext userContext;
+    private final ScheduleMapper scheduleMapper;
 
     // 일정 생성
     public ScheduleResponseDto createSchedule(Long calendarId, ScheduleRequestDto scheduleRequestDto, SiteUser user) {
         Calendar calendar = validateCalendarOwner(calendarId, user);
-//        validateScheduleForCreation(calendarId, scheduleRequestDto.startTime(), scheduleRequestDto.endTime());
-
         Schedule schedule = new Schedule(
                 calendar,
                 scheduleRequestDto.title(),
@@ -42,112 +42,80 @@ public class ScheduleService {
                 scheduleRequestDto.endTime(),
                 scheduleRequestDto.location()
         );
-
-        return mapToDto(scheduleRepository.save(schedule));
+        return scheduleMapper.toDto(scheduleRepository.save(schedule));
     }
 
     // 일정 수정
     public ScheduleResponseDto updateSchedule(Long calendarId, Long scheduleId, ScheduleRequestDto scheduleRequestDto, SiteUser user) {
-        Calendar calendar = validateCalendarOwner(calendarId, user);
-        Schedule schedule = getScheduleByIdOrThrow(scheduleId);
-
-        if (!schedule.getCalendar().getId().equals(calendarId)) {
-            throw new ServiceException("400", "해당 일정은 요청한 캘린더에 속하지 않습니다.");
-        }
-
-        if (!schedule.getUser().getId().equals(user.getId())) {
-            throw new ServiceException("403", "일정을 수정할 권한이 없습니다.");
-        }
-
-//        validateScheduleForUpdate(calendarId, scheduleRequestDto.startTime(), scheduleRequestDto.endTime(), scheduleId);
-        schedule.update(scheduleRequestDto.title(), scheduleRequestDto.description(), scheduleRequestDto.startTime(), scheduleRequestDto.endTime(), scheduleRequestDto.location());
-        return mapToDto(schedule);
+        Schedule schedule = validateScheduleOwnership(calendarId, scheduleId, user, "수정");
+        schedule.update(
+                scheduleRequestDto.title(),
+                scheduleRequestDto.description(),
+                scheduleRequestDto.startTime(),
+                scheduleRequestDto.endTime(),
+                scheduleRequestDto.location()
+        );
+        return scheduleMapper.toDto(schedule);
     }
 
     // 일정 삭제
     public void deleteSchedule(Long calendarId, Long scheduleId, SiteUser user) {
-        validateCalendarOwner(calendarId, user);
-        Schedule schedule = getScheduleByIdOrThrow(scheduleId);
-
-        if (!schedule.getCalendar().getId().equals(calendarId)) {
-            throw new ServiceException("400", "해당 일정은 요청한 캘린더에 속하지 않습니다.");
-        }
-
-        if (!schedule.getUser().getId().equals(user.getId())) {
-            throw new ServiceException("403", "일정을 삭제할 권한이 없습니다.");
-        }
-
+        Schedule schedule = validateScheduleOwnership(calendarId, scheduleId, user, "삭제");
         scheduleRepository.delete(schedule);
     }
 
-    // 특정 캘린더의 일정 목록 조회
+    // 지정 기간의 일정 목록 조회
     public List<ScheduleResponseDto> getSchedules(Long calendarId, LocalDate startDate, LocalDate endDate, SiteUser user) {
         validateCalendarOwner(calendarId, user);
-
         LocalDateTime startDateTime = startDate.atStartOfDay();
         LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
-
         return scheduleRepository.findSchedulesByCalendarAndDateRange(calendarId, startDateTime, endDateTime)
-                .stream().map(this::mapToDto).toList();
+                .stream().map(scheduleMapper::toDto).toList();
     }
 
     // 하루 일정 조회
     public List<ScheduleResponseDto> getDailySchedules(Long calendarId, LocalDate date, SiteUser user) {
         validateCalendarOwner(calendarId, user);
-
-        LocalDateTime startOfDay = date.atStartOfDay();
-        LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
-
-        return scheduleRepository.findSchedulesByCalendarAndDateRange(calendarId, startOfDay, endOfDay)
-                .stream().map(this::mapToDto).toList();
+        LocalDateTime[] range = getDayRange(date);
+        return scheduleRepository.findSchedulesByCalendarAndDateRange(calendarId, range[0], range[1])
+                .stream().map(scheduleMapper::toDto).toList();
     }
 
-    //일주일 일정 조회 (일요일 기준)
-    public List<ScheduleResponseDto> getWeeklySchedules(Long calendarId, LocalDate date, SiteUser user){
+    // 주별 일정 조회 (일요일 ~ 토요일)
+    public List<ScheduleResponseDto> getWeeklySchedules(Long calendarId, LocalDate date, SiteUser user) {
         validateCalendarOwner(calendarId, user);
-
-        // 기준 날짜가 포함된 주의 일요일 및 토요일 계산
-        LocalDate startOfWeek = date.with(DayOfWeek.SUNDAY);
-        LocalDate endOfWeek = date.with(DayOfWeek.SATURDAY);
-
-        LocalDateTime startDateTime = startOfWeek.atStartOfDay();
-        LocalDateTime endDateTime = endOfWeek.atTime(LocalTime.MAX);
-
-        return scheduleRepository.findSchedulesByCalendarAndDateRange(calendarId, startDateTime, endDateTime)
-                .stream().map(this::mapToDto).toList();
+        LocalDateTime[] range = getWeekRange(date);
+        return scheduleRepository.findSchedulesByCalendarAndDateRange(calendarId, range[0], range[1])
+                .stream().map(scheduleMapper::toDto).toList();
     }
 
-    // 한 달 일정 조회 (1일부터 말일까지)
+    // 월별 일정 조회 (해당 월의 1일 ~ 말일)
     public List<ScheduleResponseDto> getMonthlySchedules(Long calendarId, LocalDate date, SiteUser user) {
         validateCalendarOwner(calendarId, user);
-
-        // 기준 날짜의 월의 첫째 날과 마지막 날 계산
-        LocalDate firstDayOfMonth = date.withDayOfMonth(1);
-        LocalDate lastDayOfMonth = date.withDayOfMonth(date.lengthOfMonth());
-
-        LocalDateTime startDateTime = firstDayOfMonth.atStartOfDay();
-        LocalDateTime endDateTime = lastDayOfMonth.atTime(LocalTime.MAX);
-
-        return scheduleRepository.findSchedulesByCalendarAndDateRange(calendarId, startDateTime, endDateTime)
-                .stream().map(this::mapToDto).toList();
+        LocalDateTime[] range = getMonthRange(date);
+        return scheduleRepository.findSchedulesByCalendarAndDateRange(calendarId, range[0], range[1])
+                .stream().map(scheduleMapper::toDto).toList();
     }
 
-    // 특정 일정 조회
+    // 특정 일정 조회 (캘린더 소유자 검증 포함)
     public ScheduleResponseDto getScheduleById(Long calendarId, Long scheduleId, SiteUser user) {
         validateCalendarOwner(calendarId, user);
         Schedule schedule = getScheduleByIdOrThrow(scheduleId);
-
         if (!schedule.getCalendar().getId().equals(calendarId)) {
             throw new ServiceException("400", "해당 일정은 요청한 캘린더에 속하지 않습니다.");
         }
-
-        return mapToDto(schedule);
+        return scheduleMapper.toDto(schedule);
     }
 
-    // 캘린더 존재 확인
-    private Calendar getCalendarByIdOrThrow(Long calendarId) {
-        return calendarRepository.findById(calendarId)
-                .orElseThrow(() -> new ServiceException("404", "해당 캘린더를 찾을 수 없습니다."));
+    // --- 내부 헬퍼 메서드 ---
+
+    // 캘린더 존재 및 소유자 검증
+    private Calendar validateCalendarOwner(Long calendarId, SiteUser user) {
+        Calendar calendar = getCalendarByIdOrThrow(calendarId);
+        if (!calendar.getUser().getId().equals(user.getId())) {
+            throw new ServiceException("403", "캘린더 소유자만 접근할 수 있습니다.");
+        }
+        return calendar;
     }
 
     // 일정 존재 확인
@@ -156,52 +124,47 @@ public class ScheduleService {
                 .orElseThrow(() -> new ServiceException("404", "해당 일정을 찾을 수 없습니다."));
     }
 
-//    // 일정 생성 시 충돌 검사
-//    private void validateScheduleForCreation(Long calendarId, LocalDateTime startTime, LocalDateTime endTime) {
-//        List<Schedule> overlappingSchedules = scheduleRepository.findOverlappingSchedules(calendarId, startTime, endTime);
-//        if (!overlappingSchedules.isEmpty()) {
-//            throw new ServiceException("400", "해당 시간에 이미 일정이 존재합니다.");
-//        }
-//    }
-//
-//    // 일정 수정 시 충돌 검사
-//    private void validateScheduleForUpdate(Long calendarId, LocalDateTime startTime, LocalDateTime endTime, Long scheduleId) {
-//        List<Schedule> overlappingSchedules = scheduleRepository.findOverlappingSchedules(calendarId, startTime, endTime);
-//        boolean hasConflict = overlappingSchedules.stream()
-//                .anyMatch(schedule -> !schedule.getId().equals(scheduleId));
-//
-//        if (hasConflict) {
-//            throw new ServiceException("400", "해당 시간에 이미 일정이 존재합니다.");
-//        }
-//    }
-
-    // DTO 변환
-    private ScheduleResponseDto mapToDto(Schedule schedule) {
-        return new ScheduleResponseDto(
-                schedule.getId(),
-                schedule.getCalendar().getId(),
-                schedule.getTitle(),
-                schedule.getDescription(),
-                schedule.getStartTime(),
-                schedule.getEndTime(),
-                schedule.getLocation(),
-                schedule.getCreateDate(),
-                schedule.getModifyDate()
-        );
+    // 캘린더 존재 확인
+    private Calendar getCalendarByIdOrThrow(Long calendarId) {
+        return calendarRepository.findById(calendarId)
+                .orElseThrow(() -> new ServiceException("404", "해당 캘린더를 찾을 수 없습니다."));
     }
 
-    // 현재 인증된 사용자 가져오기
+    // 일정 수정/삭제 시 캘린더 및 일정 소유자 검증 (action: "수정" 또는 "삭제")
+    private Schedule validateScheduleOwnership(Long calendarId, Long scheduleId, SiteUser user, String action) {
+        validateCalendarOwner(calendarId, user);
+        Schedule schedule = getScheduleByIdOrThrow(scheduleId);
+        if (!schedule.getCalendar().getId().equals(calendarId)) {
+            throw new ServiceException("400", "해당 일정은 요청한 캘린더에 속하지 않습니다.");
+        }
+        if (!schedule.getUser().getId().equals(user.getId())) {
+            throw new ServiceException("403", "일정을 " + action + "할 권한이 없습니다.");
+        }
+        return schedule;
+    }
+
+    // 하루 날짜 범위 계산 (시작: 00:00, 종료: 23:59:59.999)
+    private LocalDateTime[] getDayRange(LocalDate date) {
+        return new LocalDateTime[]{date.atStartOfDay(), date.atTime(LocalTime.MAX)};
+    }
+
+    // 주간 날짜 범위 계산 (일요일 ~ 토요일)
+    private LocalDateTime[] getWeekRange(LocalDate date) {
+        LocalDate startOfWeek = date.with(DayOfWeek.SUNDAY);
+        LocalDate endOfWeek = date.with(DayOfWeek.SATURDAY);
+        return new LocalDateTime[]{startOfWeek.atStartOfDay(), endOfWeek.atTime(LocalTime.MAX)};
+    }
+
+    // 월간 날짜 범위 계산 (해당 월의 1일 ~ 말일)
+    private LocalDateTime[] getMonthRange(LocalDate date) {
+        LocalDate firstDay = date.withDayOfMonth(1);
+        LocalDate lastDay = date.withDayOfMonth(date.lengthOfMonth());
+        return new LocalDateTime[]{firstDay.atStartOfDay(), lastDay.atTime(LocalTime.MAX)};
+    }
+
+    // 현재 인증된 사용자 조회 (UserContext 통한 조회)
     public SiteUser getAuthenticatedUser() {
         return userContext.findActor()
                 .orElseThrow(() -> new ServiceException("401", "로그인을 먼저 해주세요!"));
-    }
-
-    // 캘린더 소유자 검증
-    private Calendar validateCalendarOwner(Long calendarId, SiteUser user) {
-        Calendar calendar = getCalendarByIdOrThrow(calendarId);
-        if (!calendar.getUser().getId().equals(user.getId())) {
-            throw new ServiceException("403", "캘린더 소유자만 접근할 수 있습니다.");
-        }
-        return calendar;
     }
 }


### PR DESCRIPTION
### 1. 공통 로직 및 중복 코드 개선
- **인증 및 검증 로직 중앙화**  
  각 API 메서드에서 중복되어 사용되던 사용자 인증 및 캘린더 소유자 검증 로직을 서비스 내부 헬퍼 메서드(예: `validateCalendarOwner`, `validateScheduleOwnership`)로 분리하여 재사용성을 높였습니다.

- **날짜 범위 계산 분리**  
  일간, 주간, 월간 일정 조회 시 날짜 범위 계산 로직을 각각 `getDayRange`, `getWeekRange`, `getMonthRange` 메서드로 추출하여 중복 코드를 제거하고 가독성을 향상시켰습니다.

---

### 2. DTO 및 매핑 관련 개선
- **MapStruct 도입**  
  기존의 수동 엔티티 → DTO 변환 코드를 MapStruct 기반 매퍼(`ScheduleMapper`)를 활용하여 `scheduleMapper.toDto()`를 호출하는 방식으로 변경했습니다.  
  이를 통해 변환 로직이 한 곳에 집중되어 유지보수성과 코드 일관성이 크게 향상되었습니다.

- **Null 처리 및 필드 매핑 개선**  
  DTO 생성 시 description, modifyDate 등의 null 값 처리 로직을 매퍼 설정 내에 포함시켰으며, 특히 백엔드 엔티티의 `calendar.id` 값을 DTO의 `calendarId`로 명시적으로 매핑하도록 아래와 같이 설정을 추가했습니다.
  ```java
  @Mapping(target = "calendarId", source = "calendar.id")
  ```
  
  **트러블 슈팅**
  https://www.notion.so/ID-null-1a34873f28dd8025a1b8e209622dcad2?pvs=4
  

---

### 3. Repository 개선
- **Named Query 활용**  
  JPQL 쿼리를 엔티티에 `@NamedQueries` 어노테이션을 이용해 정의함으로써, 가독성과 재사용성을 높였습니다.  
  Repository 인터페이스의 메서드 이름이 Named Query 이름과 일치하도록 작성되어, Spring Data JPA가 자동으로 해당 쿼리를 매핑하도록 구성했습니다.