### PR TITLE
refactor: 쿼리 최적화

### DIFF
--- a/backend/src/main/java/com/ll/TeamProject/domain/user/dto/DormantAccountProjection.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/dto/DormantAccountProjection.java
@@ -1,10 +1,6 @@
 package com.ll.TeamProject.domain.user.dto;
 
-import java.time.LocalDateTime;
-
 public interface DormantAccountProjection {
-    Long getId();
     String getNickname();
     String getEmail();
-    LocalDateTime getLastLogin();
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/repository/AuthenticationRepository.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/repository/AuthenticationRepository.java
@@ -16,11 +16,9 @@ public interface AuthenticationRepository extends JpaRepository<Authentication, 
     Optional<Authentication> findByUserId(Long userId);
 
     @Query("""
-        SELECT 
-            u.id AS id, 
-            u.nickname AS nickname, 
-            u.email AS email, 
-            a.lastLogin AS lastLogin
+        SELECT
+            u.nickname AS nickname,
+            u.email AS email
         FROM Authentication a
         JOIN a.user u
         WHERE a.lastLogin BETWEEN :startDate AND :endDate

--- a/backend/src/main/java/com/ll/TeamProject/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/user/repository/UserRepository.java
@@ -2,10 +2,15 @@ package com.ll.TeamProject.domain.user.repository;
 
 import com.ll.TeamProject.domain.user.entity.SiteUser;
 import com.ll.TeamProject.domain.user.enums.Role;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<SiteUser, Long> {
@@ -22,4 +27,30 @@ public interface UserRepository extends JpaRepository<SiteUser, Long> {
     Page<SiteUser> findByRoleAndIsDeletedFalse(Role role, PageRequest pageRequest);
 
     Optional<SiteUser> findByEmail(String email);
+
+    @Query("""
+            SELECT u.id
+            FROM SiteUser u
+            JOIN u.authentication a
+            WHERE a.lastLogin BETWEEN :startDate AND :endDate
+              AND u.isDeleted = false
+    """)
+    List<Long> findUserIdsInDateRange(@Param("startDate") LocalDateTime startDate,
+                                        @Param("endDate") LocalDateTime endDate);
+
+    @Modifying
+    @Query("UPDATE SiteUser u SET u.locked = true WHERE u.id IN :ids")
+    void bulkLockAccounts(@Param("ids") List<Long> ids);
+
+    @Modifying
+    @Query("""
+    UPDATE SiteUser u
+    SET u.username = CONCAT('deleted_', UUID()), 
+        u.email = CONCAT('deleted_', UUID(), '@deleted.com'), 
+        u.nickname = CONCAT('탈퇴한 사용자_', u.username), 
+        u.isDeleted = true, 
+        u.deletedDate = :deletedDate
+    WHERE u.id IN :userIds
+""")
+    void bulkDeleteAccounts(@Param("userIds") List<Long> userIds, @Param("deletedDate") LocalDateTime deletedDate);
 }


### PR DESCRIPTION
## 현재 상황

**사용자가 아주 많고 사용자 엔티티가 복잡한 경우**로 생각했을 때

**전체 엔티티**를 조회하지 않고 Projection 을 사용해서 **필요한 필드만 조회**하는 중.

<br>

그래서

로그인한지 11개월이 지난 사용자에게 메일 보내는 작업과 ( == 이상 없음 )

12개월과 18개월이 넘은 사용자는 잠금과 삭제 작업을 하는데

**엔티티 변경**을 위해서는 **온전한 엔티티** 조회가 필요함

그래서 각 해당하는 계정에 대해서 **하나하나 데이터베이스에서 조회**하고 있음.

<br>

예를들어 메일 대상이 1명, 잠금 대상이 2명, 삭제 대상이 3명이면,

각 Projection 쿼리 3번에

잠금과 삭제 대상 개별 엔티티 조회 쿼리 5번,

수정한 내용 반영 쿼리 5번으로 총 13번 쿼리가 날라가는 것으로 예상.

<br>

## 수정 내용

1. 메일 대상 조회 : 작업에 일부 데이터만 필요하므로 Projection 사용하는 기존 코드 유지

2. 잠금과 삭제 : **쿼리 최소화**를 위해 **id** 만 받아오고 id 의 리스트를 사용하여 **bulk 작업**

<br>

## 세부 설명

( **lastLogin 기준**으로 사용자 조회, **bulk 단위**는 100명씩으로 설정 )

1. 로그인 한지 **11개월**이 된 사용자 닉네임, 이메일 조회. -> 메일 대상

2. 메일 대상들에게 안내 **메일 전송**.

3. 로그인 한지 **12개월** 된 사용자 **id 리스트 조회** -> **잠김 (휴면) 대상**

4. 잠김 대상 id 리스트를 통해 잠금 작업, **bulk 로 한번에 최대 100 명씩**

5. 로그인 한지 **18개월** 된 사용자 **id 리스트 조회** -> **삭제 대상**

6. 삭제 대상 id 리스트를 통해 삭제 작업, **bulk 로 한번에 최대 100 명씩**

<br>

## 효과

### 기존 쿼리 수 :

Projection 쿼리 3번 (SELECT)

\+ 잠금 대상 엔티티 조회 n 번 (SELECT)

\+ 잠금 작업 n 번 (UPDATE)

\+ 삭제 대상 엔티티 조회 m 번 (SELECT)

\+ 삭제 작업 m 번  (UPDATE)

== 총 3n + 3m + 3 번

( SELECT 2n + 2m + 3 번, UPDATE n + m 번 )

### 변경 쿼리 수 :

Projection 쿼리 3번 (SELECT)

\+ 잠금 작업 n / 100 + 1 번 (UPDATE)

\+ 삭제 작업 m / 100 + 1 번  (UPDATE)

== 총 n / 100 + m / 100 + 5 번

( == **잠금, 삭제 대상이 100명 이하일 경우 5번** )

( SELECT 3 번, UPDATE n / 100 + m / 100 + 2번 )