### PR TITLE
refactor: 사용자 인증 로직 리팩토링 및 calendar dto record 변환

### DIFF
--- a/backend/src/main/java/com/ll/TeamProject/domain/calendar/controller/CalendarController.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/calendar/controller/CalendarController.java
@@ -4,9 +4,6 @@ import com.ll.TeamProject.domain.calendar.dto.CalendarCreateDto;
 import com.ll.TeamProject.domain.calendar.dto.CalendarUpdateDto;
 import com.ll.TeamProject.domain.calendar.entity.Calendar;
 import com.ll.TeamProject.domain.calendar.service.CalendarService;
-import com.ll.TeamProject.domain.user.entity.SiteUser;
-import com.ll.TeamProject.global.userContext.UserContext;
-import com.ll.TeamProject.global.exceptions.ServiceException;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,55 +20,29 @@ import java.util.List;
 public class CalendarController {
 
     private final CalendarService calendarService;
-    private final UserContext userContext;
-
-    private SiteUser getAuthenticatedUser() {
-        return userContext.findActor().orElseThrow(() -> new ServiceException("401-1", "로그인을 먼저 해주세요!"));
-    }
 
     @PostMapping
     public ResponseEntity<Calendar> createCalendar(@RequestBody CalendarCreateDto dto) {
-        SiteUser user = getAuthenticatedUser();
-        dto.setUserId(user.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(calendarService.createCalendar(dto));
     }
 
     @GetMapping
     public ResponseEntity<List<Calendar>> getAllCalendars() {
-        SiteUser user = getAuthenticatedUser();
-        return ResponseEntity.ok(calendarService.getAllCalendars(user.getId()));
+        return ResponseEntity.ok(calendarService.getAllCalendars());
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<?> getCalendarById(@PathVariable Long id) {
-        SiteUser user = getAuthenticatedUser();
-        Calendar calendar = calendarService.getCalendarById(id);
-
-        if (!calendar.getUser().getId().equals(user.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("해당 캘린더는 열 수 없어요!");
-        }
-        return ResponseEntity.ok(calendar);
+    public ResponseEntity<Calendar> getCalendarById(@PathVariable Long id) {
+        return ResponseEntity.ok(calendarService.getCalendarById(id));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> updateCalendar(@PathVariable Long id, @RequestBody CalendarUpdateDto dto) {
-        SiteUser user = getAuthenticatedUser();
-        Calendar calendar = calendarService.getCalendarById(id);
-
-        if (!calendar.getUser().getId().equals(user.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("해당 캘린더를 수정할 수 없어요!");
-        }
+    public ResponseEntity<Calendar> updateCalendar(@PathVariable Long id, @RequestBody CalendarUpdateDto dto) {
         return ResponseEntity.ok(calendarService.updateCalendar(id, dto));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteCalendar(@PathVariable Long id) {
-        SiteUser user = getAuthenticatedUser();
-        Calendar calendar = calendarService.getCalendarById(id);
-
-        if (!calendar.getUser().getId().equals(user.getId())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("해당 캘린더를 삭제할 수 없어요!");
-        }
         calendarService.deleteCalendar(id);
         return ResponseEntity.ok("캘린더가 삭제되었습니다!");
     }

--- a/backend/src/main/java/com/ll/TeamProject/domain/calendar/dto/CalendarCreateDto.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/calendar/dto/CalendarCreateDto.java
@@ -1,22 +1,4 @@
 package com.ll.TeamProject.domain.calendar.dto;
 
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
-public class CalendarCreateDto {
-    private Long userId;  // 사용자의 ID 추가
-    private String name;
-    private String description;
-
-    //생성자 추가
-    public CalendarCreateDto(String name, String description) {
-        this.name = name;
-        this.description = description;
-    }
-
-    public CalendarCreateDto() {
-
-    }
+public record CalendarCreateDto(Long userId, String name, String description) {
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/calendar/dto/CalendarDto.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/calendar/dto/CalendarDto.java
@@ -1,9 +1,4 @@
 package com.ll.TeamProject.domain.calendar.dto;
 
-import lombok.Data;
-
-@Data
-public abstract class CalendarDto {
-    private String title; // 캘린더 제목
-    private String description; // 캘린더 설명
+public record CalendarDto(String title, String description) {
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/calendar/dto/CalendarUpdateDto.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/calendar/dto/CalendarUpdateDto.java
@@ -1,12 +1,4 @@
-// CalendarUpdateDto.java
 package com.ll.TeamProject.domain.calendar.dto;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
-@Data
-@EqualsAndHashCode(callSuper = false)
-public class CalendarUpdateDto {
-    private String name;
-    private String description;
+public record CalendarUpdateDto(String name, String description) {
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/calendar/entity/Calendar.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/calendar/entity/Calendar.java
@@ -18,46 +18,46 @@ import java.util.List;
 @Builder
 public class Calendar extends BaseTime {
 
-   //캘린더 소유 사용자
+    // 캘린더 소유 사용자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private SiteUser user;
 
-    //캘린더 이름
+    // 캘린더 이름
     private String name;
 
-    //캘린더 설명
+    // 캘린더 설명
     private String description;
 
-    //공유된 사용자 목록
+    // 공유된 사용자 목록
     @OneToMany(mappedBy = "calendar", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore
     private List<SharedCalendar> sharedUsers = new ArrayList<>();
 
-    //메시지 목록
+    // 메시지 목록
     @OneToMany(mappedBy = "calendar", cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnore
     private List<Message> messageList = new ArrayList<>();
 
-    //일정 목록
+    // 일정 목록
     @OneToMany(mappedBy = "calendar", cascade = CascadeType.REMOVE)
     @JsonIgnore
     private List<Schedule> schedules = new ArrayList<>();
 
-    //비즈니스 생성자
+    // 비즈니스 생성자
     public Calendar(SiteUser user, String name, String description) {
         this.user = user;
         this.name = name;
         this.description = description;
     }
 
-    //캘린더 정보 업데이트
+    // 캘린더 정보 업데이트 (record 적용)
     public void update(CalendarUpdateDto updateDto) {
-        this.name = updateDto.getName();
-        this.description = updateDto.getDescription();
+        this.name = updateDto.name();
+        this.description = updateDto.description();
     }
 
-   //캘린더 이름 및 설명 변경
+    // 캘린더 이름 및 설명 변경
     public void update(String name, String description) {
         this.name = name;
         this.description = description;

--- a/backend/src/main/java/com/ll/TeamProject/domain/calendar/service/CalendarService.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/calendar/service/CalendarService.java
@@ -7,6 +7,7 @@ import com.ll.TeamProject.domain.calendar.repository.CalendarRepository;
 import com.ll.TeamProject.domain.user.entity.SiteUser;
 import com.ll.TeamProject.domain.user.repository.UserRepository;
 import com.ll.TeamProject.global.exceptions.ServiceException;
+import com.ll.TeamProject.global.userContext.UserContextService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,15 +23,14 @@ public class CalendarService {
 
     private final CalendarRepository calendarRepository;
     private final UserRepository userRepository;
+    private final UserContextService userContextService;
 
     private static final String USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
     private static final String CALENDAR_NOT_FOUND = "캘린더를 찾을 수 없습니다.";
 
-    //캘린더 생성
+    // 캘린더 생성
     public Calendar createCalendar(CalendarCreateDto dto) {
-        SiteUser user = userRepository.findById(dto.getUserId())
-                .orElseThrow(() -> new ServiceException("404", USER_NOT_FOUND));
-
+        SiteUser user = userContextService.getAuthenticatedUser();
         Calendar calendar = new Calendar(user, dto.getName(), dto.getDescription());
         Calendar savedCalendar = calendarRepository.save(calendar);
 
@@ -38,34 +38,48 @@ public class CalendarService {
         return savedCalendar;
     }
 
-    //특정 유저의 모든 캘린더 조회
-    public List<Calendar> getAllCalendars(Long userId) {
-        SiteUser user = userRepository.findById(userId)
-                .orElseThrow(() -> new ServiceException("404", USER_NOT_FOUND));
-
+    // 사용자의 모든 캘린더 조회
+    public List<Calendar> getAllCalendars() {
+        SiteUser user = userContextService.getAuthenticatedUser();
         return calendarRepository.findByUserId(user.getId());
     }
 
-
-    //특정 캘린더 조회
+    // 특정 캘린더 조회 (소유자 검증 포함)
     public Calendar getCalendarById(Long id) {
-        return calendarRepository.findById(id)
+        SiteUser user = userContextService.getAuthenticatedUser();
+        Calendar calendar = calendarRepository.findById(id)
                 .orElseThrow(() -> new ServiceException("404", CALENDAR_NOT_FOUND));
+
+        checkCalendarOwnership(calendar, user);
+        return calendar;
     }
 
-    //캘린더 수정
+    // 캘린더 수정 (소유자 검증 포함)
     public Calendar updateCalendar(Long id, CalendarUpdateDto dto) {
+        SiteUser user = userContextService.getAuthenticatedUser();
         Calendar calendar = getCalendarById(id);
-        calendar.update(dto);
+        checkCalendarOwnership(calendar, user);
 
+        calendar.update(dto);
         log.info("캘린더 수정 완료 - ID: {}, New Name: {}, New Description: {}", id, dto.getName(), dto.getDescription());
 
         return calendarRepository.save(calendar);
     }
 
-    //캘린더 삭제
+    // 캘린더 삭제 (소유자 검증 포함)
     public void deleteCalendar(Long id) {
+        SiteUser user = userContextService.getAuthenticatedUser();
+        Calendar calendar = getCalendarById(id);
+        checkCalendarOwnership(calendar, user);
+
         calendarRepository.deleteById(id);
         log.info("캘린더 삭제 완료 - ID: {}", id);
+    }
+
+    // 캘린더 소유자 검증
+    private void checkCalendarOwnership(Calendar calendar, SiteUser user) {
+        if (!calendar.getUser().getId().equals(user.getId())) {
+            throw new ServiceException("403", "캘린더 소유자만 접근할 수 있습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/ll/TeamProject/domain/calendar/service/CalendarService.java
+++ b/backend/src/main/java/com/ll/TeamProject/domain/calendar/service/CalendarService.java
@@ -5,7 +5,6 @@ import com.ll.TeamProject.domain.calendar.dto.CalendarUpdateDto;
 import com.ll.TeamProject.domain.calendar.entity.Calendar;
 import com.ll.TeamProject.domain.calendar.repository.CalendarRepository;
 import com.ll.TeamProject.domain.user.entity.SiteUser;
-import com.ll.TeamProject.domain.user.repository.UserRepository;
 import com.ll.TeamProject.global.exceptions.ServiceException;
 import com.ll.TeamProject.global.userContext.UserContextService;
 import jakarta.transaction.Transactional;
@@ -22,16 +21,14 @@ import java.util.List;
 public class CalendarService {
 
     private final CalendarRepository calendarRepository;
-    private final UserRepository userRepository;
     private final UserContextService userContextService;
 
-    private static final String USER_NOT_FOUND = "사용자를 찾을 수 없습니다.";
     private static final String CALENDAR_NOT_FOUND = "캘린더를 찾을 수 없습니다.";
 
     // 캘린더 생성
     public Calendar createCalendar(CalendarCreateDto dto) {
         SiteUser user = userContextService.getAuthenticatedUser();
-        Calendar calendar = new Calendar(user, dto.getName(), dto.getDescription());
+        Calendar calendar = new Calendar(user, dto.name(), dto.description());
         Calendar savedCalendar = calendarRepository.save(calendar);
 
         log.info("캘린더 생성 완료 - ID: {}, Name: {}", savedCalendar.getId(), savedCalendar.getName());
@@ -60,8 +57,8 @@ public class CalendarService {
         Calendar calendar = getCalendarById(id);
         checkCalendarOwnership(calendar, user);
 
-        calendar.update(dto);
-        log.info("캘린더 수정 완료 - ID: {}, New Name: {}, New Description: {}", id, dto.getName(), dto.getDescription());
+        calendar.update(dto.name(), dto.description());
+        log.info("캘린더 수정 완료 - ID: {}, New Name: {}, New Description: {}", id, dto.name(), dto.description());
 
         return calendarRepository.save(calendar);
     }

--- a/backend/src/main/java/com/ll/TeamProject/global/userContext/UserContextService.java
+++ b/backend/src/main/java/com/ll/TeamProject/global/userContext/UserContextService.java
@@ -1,0 +1,18 @@
+package com.ll.TeamProject.global.userContext;
+
+import com.ll.TeamProject.domain.user.entity.SiteUser;
+import com.ll.TeamProject.global.exceptions.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserContextService {
+
+    private final UserContext userContext;
+
+    public SiteUser getAuthenticatedUser() {
+        return userContext.findActor()
+                .orElseThrow(() -> new ServiceException("401", "로그인을 먼저 해주세요!"));
+    }
+}


### PR DESCRIPTION

### 작업 내용

**사용자 인증 로직을 개선하고 calendar dto를 `record`로 변환하는 리팩토링**을 수행하였습니다. 

1. **사용자 인증 로직 리팩토링**
  - `UserContextService` 추가하여 **인증 로직을 통합 관리**  
  - 기존 `getAuthenticatedUser()` 메서드를 `ScheduleService` 및 `CalendarController`에서 제거  
  - `validateScheduleOwnership` 및 `validateScheduleBelongsToCalendar` 메서드 추가로 검증 로직 개선  
  - `CalendarController`에서 **컨트롤러 레벨의 인증 제거** (→ 서비스에서 수행)


2. **DTO를 `record`로 변환**
  - `CalendarCreateDto`, `CalendarUpdateDto`, `CalendarDto` → **record로 변경**  
  - `@Getter`, `@Setter`, `@Data` 등의 Lombok 어노테이션 제거  
  - `record` 사용으로 **자동으로 `equals()`, `hashCode()`, `toString()` 제공**  
  - `CalendarService` 및 `Calendar` 엔티티에서 DTO 필드 접근을 `dto.name()` 형태로 변경 

### **변경 사항**
- 사용자 인증 로직을 서비스 레이어에서만 수행하도록 구조 개선  
- 중복된 인증 코드 제거 및 유지보수 용이성 향상  
- DTO를 `record`로 변환하여 **불변성(Immutability)** 유지  
- `CalendarService`, `ScheduleService`의 DTO 필드 접근 방식 `dto.getName()` → `dto.name()` 변경  

